### PR TITLE
Add helm cli to argocd-cmp docker image

### DIFF
--- a/argocd-cmp/Dockerfile.goreleaser
+++ b/argocd-cmp/Dockerfile.goreleaser
@@ -1,10 +1,15 @@
+FROM alpine as helm
+WORKDIR /app
+ADD https://get.helm.sh/helm-v3.13.2-linux-amd64.tar.gz helm-v3.13.2-linux-amd64.tar.gz
+RUN tar -zxvf helm-v3.13.2-linux-amd64.tar.gz
+
 FROM bash:5
 ENV ARGOCD_EXEC_TIMEOUT=90s
 COPY subst /subst
 COPY argocd-cmp/cmp.yaml /home/argocd/cmp-server/config/plugin.yaml
 COPY argocd-cmp/entrypoint.sh /entrypoint.sh
+COPY --from=helm /app/linux-amd64/helm /helm
 RUN adduser -H -D -s /bin/bash -G nobody -u 999 argocd && \
     chmod +x /entrypoint.sh
 USER argocd:nobody
 ENTRYPOINT ["/entrypoint.sh"]
-


### PR DESCRIPTION
Needed in order for https://argo-cd.readthedocs.io/en/stable/user-guide/kustomize/#kustomizing-helm-charts to work.
P.S. Intentionally used helm version v3.13.2 to match helm version used in latest ArgoCD release (v2.10.2).