### PR TITLE
Fix substitutions command & typos

### DIFF
--- a/pkg/subst/substitutions.go
+++ b/pkg/subst/substitutions.go
@@ -87,12 +87,12 @@ func (s *Substitutions) Add(data map[interface{}]interface{}, optimistic bool) (
 
 	tree, err := s.Eval(data, nil, optimistic)
 	if err != nil {
-		return fmt.Errorf("failed to build subtitutions: %s", err)
+		return fmt.Errorf("failed to build substitutions: %s", err)
 	}
 
 	merge, err := spruce.Merge(s.Get(), tree)
 	if err != nil {
-		return fmt.Errorf("could not merge manifest with subtitutions: %s", err)
+		return fmt.Errorf("could not merge manifest with substitutions: %s", err)
 	}
 
 	s.Subst = merge
@@ -111,7 +111,7 @@ func (s *Substitutions) Eval(data map[interface{}]interface{}, substs map[interf
 
 	merge, err := spruce.Merge(data, sub)
 	if err != nil {
-		return nil, fmt.Errorf("could not merge manifest with subtitutions: %s", err)
+		return nil, fmt.Errorf("could not merge manifest with substitutions: %s", err)
 	}
 
 	if optimistic {

--- a/subst/cmd/substitutions.go
+++ b/subst/cmd/substitutions.go
@@ -40,6 +40,12 @@ func substitutions(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
+	err = m.BuildSubstitutions()
+	if err != nil {
+		return err
+	}
+
 	if m != nil {
 		if len(m.Substitutions.Subst) > 0 {
 			if configuration.Output == "json" {


### PR DESCRIPTION
Before when running `subst substitutions` there was a segmentation fault:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x2f56729]
```